### PR TITLE
Fix for channels without secondaryLinks defined

### DIFF
--- a/app/youtube-grabber.js
+++ b/app/youtube-grabber.js
@@ -36,15 +36,17 @@ class YoutubeGrabber {
           title: x.title.simpleText
         }
       })
-      links.secondaryLinks = channelHeaderLinksData.secondaryLinks.map(x => {
-        const url = x.navigationEndpoint.urlEndpoint.url
-        const match = url.match('&q=(.*)')
-        return {
-          url: match === null ? url : decodeURIComponent(match[1]),
-          icon: x.icon.thumbnails[0].url,
-          title: x.title.simpleText
-        }
-      })
+      if (typeof links.secondaryLinks !== 'undefined') {
+        links.secondaryLinks = channelHeaderLinksData.secondaryLinks.map(x => {
+          const url = x.navigationEndpoint.urlEndpoint.url
+          const match = url.match('&q=(.*)')
+          return {
+            url: match === null ? url : decodeURIComponent(match[1]),
+            icon: x.icon.thumbnails[0].url,
+            title: x.title.simpleText
+          }
+        })
+      }
     }
 
     if (typeof (channelPageResponse.data[1].response.alerts) !== 'undefined') {


### PR DESCRIPTION
I had a channel with only primary links, causing the error:

  debug TypeError: Cannot read property 'map' of undefined
  debug     at Function.getChannelInfo (/***/***/node_modules/yt-channel-info/app/youtube-grabber.js:40:68)

The structure of 'links' at that point was:
{
  primaryLinks: [ { navigationEndpoint: [Object], icon: [Object], title: [Object] } ]
}
rather than:
{
  primaryLinks: [ { navigationEndpoint: [Object], icon: [Object], title: [Object] } ],
  secondaryLinks: [ { navigationEndpoint: [Object], icon: [Object], title: [Object] } ]
}

Not sure if you need to create empty secondaryLinks array instead at that point, but this fix works fine for me.